### PR TITLE
feat: 실험실 개설 요청 기능, 일부 설정 및 엔티티 수정

### DIFF
--- a/src/main/java/com/labify/backend/config/SecurityConfig.java
+++ b/src/main/java/com/labify/backend/config/SecurityConfig.java
@@ -28,11 +28,13 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 // HTTP 요청에 대한 접근 권한 설정
                 .authorizeHttpRequests(auth -> auth
-                        // 아래 경로로 오는 요청은 인증 없이 모두 허용
-                        .requestMatchers("/facilities/*", "/labs/*", "/relation/**").permitAll()
-                        .requestMatchers("/api/auth/**").permitAll()
-                        // 그 외 나머지 모든 요청은 인증을 요구
-                        .anyRequest().authenticated());
+                                // ⭐ 모든 요청을 인증 없이 허용하도록 임시 변경
+                                .anyRequest().permitAll());
+//                        // 아래 경로로 오는 요청은 인증 없이 모두 허용
+//                        .requestMatchers("/facilities/*", "/labs/**", "/relation/**").permitAll()
+//                        .requestMatchers("/api/auth/**").permitAll()
+//                        // 그 외 나머지 모든 요청은 인증을 요구
+//                        .anyRequest().authenticated());
 
         return http.build();
     }

--- a/src/main/java/com/labify/backend/facility/relation/controller/RelationshipController.java
+++ b/src/main/java/com/labify/backend/facility/relation/controller/RelationshipController.java
@@ -1,16 +1,13 @@
-package com.labify.backend.relation.controller;
+package com.labify.backend.facility.relation.controller;
 
-import com.labify.backend.relation.dto.RelationshipRequestDto;
-import com.labify.backend.relation.dto.RelationshipResponseDto;
-import com.labify.backend.relation.entity.Relationship;
-import com.labify.backend.relation.service.RelationshipService;
+import com.labify.backend.facility.relation.dto.RelationshipRequestDto;
+import com.labify.backend.facility.relation.dto.RelationshipResponseDto;
+import com.labify.backend.facility.relation.entity.Relationship;
+import com.labify.backend.facility.relation.service.RelationshipService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/relation")
@@ -25,5 +22,12 @@ public class RelationshipController {
         Relationship newRelationship = relationshipService.createRelationship(requestDto);
         RelationshipResponseDto responseDto = RelationshipResponseDto.from(newRelationship);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+
+    // [DELETE] /relation/delete/{relationshipId}
+    @DeleteMapping("/delete/{relationshipId}")
+    public ResponseEntity<Void> deleteRelationship(@PathVariable Long relationshipId) {
+        relationshipService.deleteRelationship(relationshipId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/labify/backend/facility/relation/dto/RelationshipRequestDto.java
+++ b/src/main/java/com/labify/backend/facility/relation/dto/RelationshipRequestDto.java
@@ -1,4 +1,4 @@
-package com.labify.backend.relation.dto;
+package com.labify.backend.facility.relation.dto;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/labify/backend/facility/relation/dto/RelationshipResponseDto.java
+++ b/src/main/java/com/labify/backend/facility/relation/dto/RelationshipResponseDto.java
@@ -1,6 +1,6 @@
-package com.labify.backend.relation.dto;
+package com.labify.backend.facility.relation.dto;
 
-import com.labify.backend.relation.entity.Relationship;
+import com.labify.backend.facility.relation.entity.Relationship;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/labify/backend/facility/relation/entity/Relationship.java
+++ b/src/main/java/com/labify/backend/facility/relation/entity/Relationship.java
@@ -1,4 +1,4 @@
-package com.labify.backend.relation.entity;
+package com.labify.backend.facility.relation.entity;
 
 import com.labify.backend.facility.entity.Facility;
 import jakarta.persistence.*;

--- a/src/main/java/com/labify/backend/facility/relation/repository/RelationshipRepository.java
+++ b/src/main/java/com/labify/backend/facility/relation/repository/RelationshipRepository.java
@@ -1,0 +1,13 @@
+package com.labify.backend.facility.relation.repository;
+
+import com.labify.backend.facility.entity.Facility;
+import com.labify.backend.facility.relation.entity.Relationship;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RelationshipRepository extends JpaRepository<Relationship, Long> {
+
+    // 연구소와 수거 업체 사이 관계가 이미 존재하는지 검증하는 메서드
+    boolean existsByLabFacilityAndPickupFacility(Facility labFacility, Facility pickupFacility);
+}

--- a/src/main/java/com/labify/backend/facility/relation/service/RelationshipService.java
+++ b/src/main/java/com/labify/backend/facility/relation/service/RelationshipService.java
@@ -1,10 +1,10 @@
-package com.labify.backend.relation.service;
+package com.labify.backend.facility.relation.service;
 
 import com.labify.backend.facility.entity.Facility;
 import com.labify.backend.facility.repository.FacilityRepository;
-import com.labify.backend.relation.dto.RelationshipRequestDto;
-import com.labify.backend.relation.entity.Relationship;
-import com.labify.backend.relation.repository.RelationshipRepository;
+import com.labify.backend.facility.relation.dto.RelationshipRequestDto;
+import com.labify.backend.facility.relation.entity.Relationship;
+import com.labify.backend.facility.relation.repository.RelationshipRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,20 +19,28 @@ public class RelationshipService {
 
     @Transactional
     public Relationship createRelationship(RelationshipRequestDto dto) {
-        // 1. DTO에 담겨온 연구소 시설 ID로 Facility 조회
         Facility labFacility = facilityRepository.findById(dto.getLabFacilityId())
                 .orElseThrow(() -> new EntityNotFoundException("LabFacility Not Found"));
-
-        // 2. DTO에 담겨온 수거업체 시설 ID로 Facility 조회
         Facility pickupFacility = facilityRepository.findById(dto.getPickupFacilityId())
                 .orElseThrow(() -> new EntityNotFoundException("PickupFacility Not Found"));
 
-        // 3. 관계 설정
+        boolean alreadyExists = relationshipRepository.existsByLabFacilityAndPickupFacility(labFacility, pickupFacility);
+        if (alreadyExists) {
+            throw new IllegalStateException("이미 해당 시설들 사이의 관계가 존재합니다.");
+        }
+
         Relationship relationship = new Relationship();
         relationship.setLabFacility(labFacility);
         relationship.setPickupFacility(pickupFacility);
-        
-        // 4. 엔티티 저장 및 반환
+
         return relationshipRepository.save(relationship);
+    }
+
+    @Transactional
+    public void deleteRelationship(Long relationshipId) {
+        Relationship relationship = relationshipRepository.findById(relationshipId)
+                .orElseThrow(() -> new EntityNotFoundException("관계를 찾을 수 없습니다. ID: " + relationshipId));
+
+        relationshipRepository.delete(relationship);
     }
 }

--- a/src/main/java/com/labify/backend/lab/controller/LabController.java
+++ b/src/main/java/com/labify/backend/lab/controller/LabController.java
@@ -2,15 +2,13 @@ package com.labify.backend.lab.controller;
 
 import com.labify.backend.lab.dto.LabRequestDto;
 import com.labify.backend.lab.dto.LabResponseDto;
+import com.labify.backend.lab.dto.LabUpdateRequestDto;
 import com.labify.backend.lab.entity.Lab;
 import com.labify.backend.lab.service.LabService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/labs")
@@ -25,5 +23,15 @@ public class LabController {
         Lab newLab = labService.registerLab(requestDto);
         LabResponseDto responseDto = LabResponseDto.from(newLab);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+
+    // [PATCH] /labs/{labsId}
+    @PatchMapping("/{labId}")
+    public ResponseEntity<LabResponseDto> updateLab(
+            @PathVariable Long labId,
+            @RequestBody LabUpdateRequestDto requestDto) {
+        Lab updateLab = labService.updateLab(labId, requestDto);
+        LabResponseDto responseDto = LabResponseDto.from(updateLab);
+        return ResponseEntity.ok(responseDto);
     }
 }

--- a/src/main/java/com/labify/backend/lab/dto/LabUpdateRequestDto.java
+++ b/src/main/java/com/labify/backend/lab/dto/LabUpdateRequestDto.java
@@ -1,0 +1,11 @@
+package com.labify.backend.lab.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LabUpdateRequestDto {
+    private String name;
+    private String location;
+}

--- a/src/main/java/com/labify/backend/lab/request/controller/LabRequestController.java
+++ b/src/main/java/com/labify/backend/lab/request/controller/LabRequestController.java
@@ -1,5 +1,7 @@
 package com.labify.backend.lab.request.controller;
 
+import com.labify.backend.lab.dto.LabResponseDto;
+import com.labify.backend.lab.entity.Lab;
 import com.labify.backend.lab.request.dto.LabRequestCreateDto;
 import com.labify.backend.lab.request.dto.LabRequestResponseDto;
 import com.labify.backend.lab.request.entity.LabRequest;
@@ -7,10 +9,7 @@ import com.labify.backend.lab.request.service.LabRequestService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/labs/requests")
@@ -19,9 +18,24 @@ public class LabRequestController {
 
     private final LabRequestService labRequestService;
 
+    // [POST] /labs/requests
     @PostMapping
     public ResponseEntity<LabRequestResponseDto> createLabRequest(@RequestBody LabRequestCreateDto requestDto) {
         LabRequest newRequest = labRequestService.createLabRequest(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(LabRequestResponseDto.from(newRequest));
+    }
+
+    // [PATCH] /labs/requests/{requestId}/confirm
+    @PatchMapping("/{requestId}/confirm")
+    public ResponseEntity<LabResponseDto> confirmLabRequest(@PathVariable Long requestId) {
+        Lab newLab = labRequestService.confirmLabRequest(requestId);
+        return ResponseEntity.ok(LabResponseDto.from(newLab));
+    }
+
+    // [PATCH] /labs/requests/{requestId}/confirm
+    @PatchMapping("/{requestId}/reject")
+    public ResponseEntity<LabRequestResponseDto> rejectLabRequest(@PathVariable Long requestId) {
+        LabRequest rejectedRequest = labRequestService.rejectLabRequest(requestId);
+        return ResponseEntity.ok(LabRequestResponseDto.from(rejectedRequest));
     }
 }

--- a/src/main/java/com/labify/backend/lab/request/controller/LabRequestController.java
+++ b/src/main/java/com/labify/backend/lab/request/controller/LabRequestController.java
@@ -1,0 +1,27 @@
+package com.labify.backend.lab.request.controller;
+
+import com.labify.backend.lab.request.dto.LabRequestCreateDto;
+import com.labify.backend.lab.request.dto.LabRequestResponseDto;
+import com.labify.backend.lab.request.entity.LabRequest;
+import com.labify.backend.lab.request.service.LabRequestService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/labs/requests")
+@RequiredArgsConstructor
+public class LabRequestController {
+
+    private final LabRequestService labRequestService;
+
+    @PostMapping
+    public ResponseEntity<LabRequestResponseDto> createLabRequest(@RequestBody LabRequestCreateDto requestDto) {
+        LabRequest newRequest = labRequestService.createLabRequest(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(LabRequestResponseDto.from(newRequest));
+    }
+}

--- a/src/main/java/com/labify/backend/lab/request/dto/LabRequestCreateDto.java
+++ b/src/main/java/com/labify/backend/lab/request/dto/LabRequestCreateDto.java
@@ -1,0 +1,13 @@
+package com.labify.backend.lab.request.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LabRequestCreateDto {
+    private Long facilityId;
+    private String name;
+    private String location;
+    private Long managerId;
+}

--- a/src/main/java/com/labify/backend/lab/request/dto/LabRequestResponseDto.java
+++ b/src/main/java/com/labify/backend/lab/request/dto/LabRequestResponseDto.java
@@ -1,0 +1,19 @@
+package com.labify.backend.lab.request.dto;
+
+import com.labify.backend.lab.request.entity.LabRequest;
+import lombok.Getter;
+
+@Getter
+public class LabRequestResponseDto {
+    private final Long requestId;
+    private final String status;;
+
+    private LabRequestResponseDto(LabRequest entity) {
+        this.requestId = entity.getRequestId();
+        this.status = entity.getStatus().name();
+    }
+
+    public static LabRequestResponseDto from(LabRequest entity) {
+        return new LabRequestResponseDto(entity);
+    }
+}

--- a/src/main/java/com/labify/backend/lab/request/entity/LabRequest.java
+++ b/src/main/java/com/labify/backend/lab/request/entity/LabRequest.java
@@ -1,0 +1,39 @@
+package com.labify.backend.lab.request.entity;
+
+import com.labify.backend.facility.entity.Facility;
+import com.labify.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "lab_request")
+@Getter
+@Setter
+public class LabRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long requestId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "facility_id", nullable = false)
+    private Facility facility;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "manager_id", nullable = false)
+    private User manager;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String location;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RequestStatus status;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/labify/backend/lab/request/entity/RequestStatus.java
+++ b/src/main/java/com/labify/backend/lab/request/entity/RequestStatus.java
@@ -1,0 +1,7 @@
+package com.labify.backend.lab.request.entity;
+
+public enum RequestStatus {
+    PENDING,
+    CONFIRMED,
+    REJECTED
+}

--- a/src/main/java/com/labify/backend/lab/request/repository/LabRequestRepository.java
+++ b/src/main/java/com/labify/backend/lab/request/repository/LabRequestRepository.java
@@ -1,0 +1,9 @@
+package com.labify.backend.lab.request.repository;
+
+import com.labify.backend.lab.request.entity.LabRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LabRequestRepository extends JpaRepository<LabRequest, Long> {
+}

--- a/src/main/java/com/labify/backend/lab/request/service/LabRequestService.java
+++ b/src/main/java/com/labify/backend/lab/request/service/LabRequestService.java
@@ -1,0 +1,42 @@
+package com.labify.backend.lab.request.service;
+
+import com.labify.backend.facility.entity.Facility;
+import com.labify.backend.facility.repository.FacilityRepository;
+import com.labify.backend.lab.request.dto.LabRequestCreateDto;
+import com.labify.backend.lab.request.entity.LabRequest;
+import com.labify.backend.lab.request.entity.RequestStatus;
+import com.labify.backend.lab.request.repository.LabRequestRepository;
+import com.labify.backend.user.entity.User;
+import com.labify.backend.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class LabRequestService {
+
+    private final LabRequestRepository labRequestRepository;
+    private final FacilityRepository facilityRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public LabRequest createLabRequest(LabRequestCreateDto dto) {
+        Facility facility = facilityRepository.findById(dto.getFacilityId())
+                .orElseThrow(() -> new EntityNotFoundException("Facility not found"));
+        User manager = userRepository.findById(dto.getManagerId())
+                .orElseThrow(() -> new EntityNotFoundException("User not found"));
+
+        LabRequest labRequest = new LabRequest();
+        labRequest.setFacility(facility);
+        labRequest.setManager(manager);
+        labRequest.setName(dto.getName());
+        labRequest.setLocation(dto.getLocation());
+        labRequest.setStatus(RequestStatus.PENDING); // 최초 상태는 PENDING
+        labRequest.setCreatedAt(LocalDateTime.now());
+
+        return labRequestRepository.save(labRequest);
+    }
+}

--- a/src/main/java/com/labify/backend/lab/request/service/LabRequestService.java
+++ b/src/main/java/com/labify/backend/lab/request/service/LabRequestService.java
@@ -2,7 +2,10 @@ package com.labify.backend.lab.request.service;
 
 import com.labify.backend.facility.entity.Facility;
 import com.labify.backend.facility.repository.FacilityRepository;
+import com.labify.backend.lab.entity.Lab;
+import com.labify.backend.lab.repository.LabRepository;
 import com.labify.backend.lab.request.dto.LabRequestCreateDto;
+import com.labify.backend.lab.request.dto.LabRequestResponseDto;
 import com.labify.backend.lab.request.entity.LabRequest;
 import com.labify.backend.lab.request.entity.RequestStatus;
 import com.labify.backend.lab.request.repository.LabRequestRepository;
@@ -21,6 +24,7 @@ public class LabRequestService {
     private final LabRequestRepository labRequestRepository;
     private final FacilityRepository facilityRepository;
     private final UserRepository userRepository;
+    private final LabRepository labRepository;
 
     @Transactional
     public LabRequest createLabRequest(LabRequestCreateDto dto) {
@@ -31,12 +35,44 @@ public class LabRequestService {
 
         LabRequest labRequest = new LabRequest();
         labRequest.setFacility(facility);
-        labRequest.setManager(manager);
+        labRequest.setManager(manager); // 요청자?
         labRequest.setName(dto.getName());
         labRequest.setLocation(dto.getLocation());
         labRequest.setStatus(RequestStatus.PENDING); // 최초 상태는 PENDING
         labRequest.setCreatedAt(LocalDateTime.now());
 
         return labRequestRepository.save(labRequest);
+    }
+
+    @Transactional
+    public Lab confirmLabRequest(Long requestId) {
+        LabRequest request = labRequestRepository.findById(requestId)
+                .orElseThrow(() -> new EntityNotFoundException("실험실을 찾을 수 없습니다"));
+
+        if (request.getStatus() != RequestStatus.PENDING) {
+            throw new IllegalStateException("이미 처리된 요청입니다.");
+        }
+
+        request.setStatus(RequestStatus.CONFIRMED);
+
+        Lab newLab = new Lab();
+        newLab.setName(request.getName());
+        newLab.setLocation(request.getLocation());
+        newLab.setFacility(request.getFacility());
+
+        return labRepository.save(newLab);
+    }
+
+    @Transactional
+    public LabRequest rejectLabRequest(Long requestId) {
+        LabRequest request = labRequestRepository.findById(requestId)
+                .orElseThrow(() -> new EntityNotFoundException("실험실을 찾을 수 없습니다"));
+
+        if (request.getStatus() != RequestStatus.PENDING) {
+            throw new IllegalStateException("이미 처리된 요청입니다.");
+        }
+
+        request.setStatus(RequestStatus.REJECTED);
+        return labRequestRepository.save(request);
     }
 }

--- a/src/main/java/com/labify/backend/lab/service/LabService.java
+++ b/src/main/java/com/labify/backend/lab/service/LabService.java
@@ -3,8 +3,10 @@ package com.labify.backend.lab.service;
 import com.labify.backend.facility.entity.Facility;
 import com.labify.backend.facility.repository.FacilityRepository;
 import com.labify.backend.lab.dto.LabRequestDto;
+import com.labify.backend.lab.dto.LabUpdateRequestDto;
 import com.labify.backend.lab.entity.Lab;
 import com.labify.backend.lab.repository.LabRepository;
+import com.labify.backend.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +18,7 @@ public class LabService {
 
     private final LabRepository labRepository;
     private final FacilityRepository facilityRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     public Lab registerLab(LabRequestDto dto) {
@@ -28,5 +31,21 @@ public class LabService {
         lab.setFacility(facility);
 
         return labRepository.save(lab);
+    }
+
+    @Transactional
+    public Lab updateLab(Long labId, LabUpdateRequestDto dto) {
+        Lab existingLab = labRepository.findById(labId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 실험실을 찾을 수 없습니다."));
+
+        // DTO에 값이 있는 필드만 선택적으로 업데이트
+        if (dto.getName() != null) {
+            existingLab.setName(dto.getName());
+        }
+        if (dto.getLocation() != null) {
+            existingLab.setLocation(dto.getLocation());
+        }
+
+        return existingLab;
     }
 }

--- a/src/main/java/com/labify/backend/relation/repository/RelationshipRepository.java
+++ b/src/main/java/com/labify/backend/relation/repository/RelationshipRepository.java
@@ -1,9 +1,0 @@
-package com.labify.backend.relation.repository;
-
-import com.labify.backend.relation.entity.Relationship;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface RelationshipRepository extends JpaRepository<Relationship, Long> {
-}

--- a/src/main/java/com/labify/backend/user/entity/User.java
+++ b/src/main/java/com/labify/backend/user/entity/User.java
@@ -37,6 +37,7 @@ public class User {
     private boolean agreeTerms; // 약관 동의
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private UserStatus status;
 
     private LocalDateTime lastLoginAt;


### PR DESCRIPTION
## 📌 작업 유형 (해당 사항 체크)
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정
- [x] 🔧 설정 변경

---

## ✏️ 관련 이슈
- X


## 📖 작업 내용
- 실험실 개설 요청 api 추가
- 실험실 개설 요청 허용/거절 api 추가
- 실험실 정보 수정 api 추가
- 연구소-수거 업체간 관계 삭제 api 추가
- users 테이블의 userState 항목을 STRING 타입으로 저장할 수 있도록 변경
- 보안 설정을 낮춰 postman 테스트가 용이하도록 함


## 🌳 반영 브랜치
- `ex. ownue -> main`


## 🌟 체크리스트
- [ ] 불필요한 코드/로그 제거
