### PR TITLE
feat: 사용자 시설 가입 요청 및 관계 생성 api 추가

### DIFF
--- a/src/main/java/com/labify/backend/facility/repository/FacilityRepository.java
+++ b/src/main/java/com/labify/backend/facility/repository/FacilityRepository.java
@@ -4,7 +4,12 @@ import com.labify.backend.facility.entity.Facility;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface FacilityRepository extends JpaRepository<Facility, Long> {
     boolean existsByFacilityCode(String facilityCode);
+
+    // 코드로 시설 id 조회
+    Optional<Facility> findByFacilityCode(String facilityCode);
 }

--- a/src/main/java/com/labify/backend/inviterequest/controller/InviteRequestController.java
+++ b/src/main/java/com/labify/backend/inviterequest/controller/InviteRequestController.java
@@ -1,0 +1,41 @@
+package com.labify.backend.inviterequest.controller;
+
+import com.labify.backend.inviterequest.dto.InviteRequestCreateDto;
+import com.labify.backend.inviterequest.dto.InviteRequestResponseDto;
+import com.labify.backend.inviterequest.entity.InviteRequest;
+import com.labify.backend.inviterequest.service.InviteRequestService;
+import com.labify.backend.userfacilityrelation.dto.UserFacilityRelationResponseDto;
+import com.labify.backend.userfacilityrelation.entity.UserFacilityRelation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/facilities/request")
+@RequiredArgsConstructor
+public class InviteRequestController {
+
+    private final InviteRequestService inviteRequestService;
+
+    // [POST] /facilities/request
+    @PostMapping
+    public ResponseEntity<InviteRequestResponseDto> createInviteRequest(@RequestBody InviteRequestCreateDto requestDto) {
+        InviteRequest newRequest = inviteRequestService.createInviteRequest(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(InviteRequestResponseDto.from(newRequest));
+    }
+
+    // [PATCH] /facilities/request/{requestId}/confirm
+    @PatchMapping("/{requestId}/confirm")
+    public ResponseEntity<UserFacilityRelationResponseDto> confirmInviteRequest(@PathVariable Long requestId) {
+        UserFacilityRelation relation = inviteRequestService.confirmInviteRequest(requestId);
+        return ResponseEntity.ok(UserFacilityRelationResponseDto.from(relation));
+    }
+
+    // [PATCH] /facilities/request/{requestId}/reject
+    @PatchMapping("/{requestId}/reject")
+    public ResponseEntity<InviteRequestResponseDto> rejectInviteRequest(@PathVariable Long requestId) {
+        InviteRequest request = inviteRequestService.rejectInviteRequest(requestId);
+        return ResponseEntity.ok(InviteRequestResponseDto.from(request));
+    }
+}

--- a/src/main/java/com/labify/backend/inviterequest/dto/InviteRequestCreateDto.java
+++ b/src/main/java/com/labify/backend/inviterequest/dto/InviteRequestCreateDto.java
@@ -1,0 +1,11 @@
+package com.labify.backend.inviterequest.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class InviteRequestCreateDto {
+    private Long userId;
+    private String facilityCode;
+}

--- a/src/main/java/com/labify/backend/inviterequest/dto/InviteRequestResponseDto.java
+++ b/src/main/java/com/labify/backend/inviterequest/dto/InviteRequestResponseDto.java
@@ -1,0 +1,20 @@
+package com.labify.backend.inviterequest.dto;
+
+import com.labify.backend.inviterequest.entity.InviteRequest;
+import com.labify.backend.inviterequest.entity.InviteStatus;
+import lombok.Getter;
+
+@Getter
+public class InviteRequestResponseDto {
+    private final Long requestId;
+    private final InviteStatus status;
+
+    private InviteRequestResponseDto(InviteRequest entity) {
+        this.requestId = entity.getId();
+        this.status = entity.getStatus();
+    }
+
+    public static InviteRequestResponseDto from(InviteRequest entity) {
+        return new InviteRequestResponseDto(entity);
+    }
+}

--- a/src/main/java/com/labify/backend/inviterequest/entity/InviteRequest.java
+++ b/src/main/java/com/labify/backend/inviterequest/entity/InviteRequest.java
@@ -1,0 +1,35 @@
+package com.labify.backend.inviterequest.entity;
+
+import com.labify.backend.facility.entity.Facility;
+import com.labify.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "invite_request")
+@Getter
+@Setter
+public class InviteRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user; // 요청을 보낸 사용자
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "facility_id", nullable = false)
+    private Facility facility; // 가입을 요청할 시설
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private InviteStatus status;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/labify/backend/inviterequest/entity/InviteStatus.java
+++ b/src/main/java/com/labify/backend/inviterequest/entity/InviteStatus.java
@@ -1,0 +1,7 @@
+package com.labify.backend.inviterequest.entity;
+
+public enum InviteStatus {
+    PENDING,  // 대기 중
+    CONFIRMED, // 수락
+    REJECTED  // 거절
+}

--- a/src/main/java/com/labify/backend/inviterequest/repository/InviteRequestRepository.java
+++ b/src/main/java/com/labify/backend/inviterequest/repository/InviteRequestRepository.java
@@ -1,0 +1,15 @@
+package com.labify.backend.inviterequest.repository;
+
+import com.labify.backend.facility.entity.Facility;
+import com.labify.backend.inviterequest.entity.InviteRequest;
+import com.labify.backend.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface InviteRequestRepository extends JpaRepository<InviteRequest, Long> {
+    // 이미 가입 요청이 존재하는지 조회
+    boolean existsByUserAndFacility(User user, Facility facility);
+}

--- a/src/main/java/com/labify/backend/inviterequest/service/InviteRequestService.java
+++ b/src/main/java/com/labify/backend/inviterequest/service/InviteRequestService.java
@@ -1,0 +1,81 @@
+package com.labify.backend.inviterequest.service;
+
+import com.labify.backend.facility.entity.Facility;
+import com.labify.backend.facility.repository.FacilityRepository;
+import com.labify.backend.inviterequest.dto.InviteRequestCreateDto;
+import com.labify.backend.inviterequest.dto.InviteRequestResponseDto;
+import com.labify.backend.inviterequest.entity.InviteRequest;
+import com.labify.backend.inviterequest.entity.InviteStatus;
+import com.labify.backend.inviterequest.repository.InviteRequestRepository;
+import com.labify.backend.userfacilityrelation.entity.UserFacilityRelation;
+import com.labify.backend.userfacilityrelation.repository.UserFacilityRelationRepository;
+import com.labify.backend.user.entity.User;
+import com.labify.backend.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class InviteRequestService {
+
+    private final InviteRequestRepository inviteRequestRepository;
+    private final UserRepository userRepository;
+    private final FacilityRepository facilityRepository;
+    private final UserFacilityRelationRepository userFacilityRelationRepository;
+
+    @Transactional
+    public InviteRequest createInviteRequest(InviteRequestCreateDto dto) {
+        User user = userRepository.findById(dto.getUserId())
+                .orElseThrow(() -> new EntityNotFoundException("User not found"));
+        Facility facility = facilityRepository.findByFacilityCode(dto.getFacilityCode())
+                .orElseThrow(() -> new EntityNotFoundException("Facility not found"));
+
+        // 동일한 사용자가 동일한 시설에 보낸 요청이 있는지 확인
+        if (inviteRequestRepository.existsByUserAndFacility(user, facility)) {
+            throw new IllegalStateException("이미 해당 시설에 가입을 요청했습니다.");
+        }
+
+        InviteRequest inviteRequest = new InviteRequest();
+        inviteRequest.setUser(user);
+        inviteRequest.setFacility(facility);
+        inviteRequest.setStatus(InviteStatus.PENDING);
+        inviteRequest.setCreatedAt(LocalDateTime.now());
+
+        return inviteRequestRepository.save(inviteRequest);
+    }
+
+    @Transactional
+    public UserFacilityRelation confirmInviteRequest(Long requestId) {
+        InviteRequest request =  inviteRequestRepository.findById(requestId)
+                .orElseThrow(() -> new EntityNotFoundException("Request not found"));
+
+        if (!request.getStatus().equals(InviteStatus.PENDING)) {
+            throw new IllegalStateException("이미 처리된 요청입니다.");
+        }
+
+        request.setStatus(InviteStatus.CONFIRMED);
+
+        UserFacilityRelation relation = new UserFacilityRelation();
+        relation.setUser(request.getUser());
+        relation.setFacility(request.getFacility());
+
+        return userFacilityRelationRepository.save(relation);
+    }
+
+    @Transactional
+    public InviteRequest rejectInviteRequest(Long requestId) {
+        InviteRequest request =  inviteRequestRepository.findById(requestId)
+                .orElseThrow(() -> new EntityNotFoundException("Request not found"));
+
+        if (!request.getStatus().equals(InviteStatus.PENDING)) {
+            throw new IllegalStateException("이미 처리된 요청입니다.");
+        }
+
+        request.setStatus(InviteStatus.REJECTED);
+        return request;
+    }
+}

--- a/src/main/java/com/labify/backend/userfacilityrelation/dto/UserFacilityRelationResponseDto.java
+++ b/src/main/java/com/labify/backend/userfacilityrelation/dto/UserFacilityRelationResponseDto.java
@@ -1,0 +1,21 @@
+package com.labify.backend.userfacilityrelation.dto;
+
+import com.labify.backend.userfacilityrelation.entity.UserFacilityRelation;
+import lombok.Getter;
+
+@Getter
+public class UserFacilityRelationResponseDto {
+    private final Long relationId;
+    private final Long userId;
+    private final Long facilityId;
+
+    private UserFacilityRelationResponseDto(UserFacilityRelation entity) {
+        this.relationId = entity.getId();
+        this.userId = entity.getUser().getUserId();
+        this.facilityId = entity.getFacility().getFacilityId();
+    }
+
+    public static UserFacilityRelationResponseDto from(UserFacilityRelation entity) {
+        return new UserFacilityRelationResponseDto(entity);
+    }
+}

--- a/src/main/java/com/labify/backend/userfacilityrelation/entity/UserFacilityRelation.java
+++ b/src/main/java/com/labify/backend/userfacilityrelation/entity/UserFacilityRelation.java
@@ -1,0 +1,26 @@
+package com.labify.backend.userfacilityrelation.entity; // 새 패키지를 만듭니다.
+
+import com.labify.backend.facility.entity.Facility;
+import com.labify.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "user_facility_relation")
+@Getter
+@Setter
+public class UserFacilityRelation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "facility_id", nullable = false)
+    private Facility facility;
+}

--- a/src/main/java/com/labify/backend/userfacilityrelation/repository/UserFacilityRelationRepository.java
+++ b/src/main/java/com/labify/backend/userfacilityrelation/repository/UserFacilityRelationRepository.java
@@ -1,0 +1,9 @@
+package com.labify.backend.userfacilityrelation.repository;
+
+import com.labify.backend.userfacilityrelation.entity.UserFacilityRelation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserFacilityRelationRepository extends JpaRepository<UserFacilityRelation, Long> {
+}


### PR DESCRIPTION
## 📌 작업 유형 (해당 사항 체크)
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정
- [ ] 🔧 설정 변경

---

## ✏️ 관련 이슈
- X


## 📖 작업 내용
- 각 role의 사용자가 시설에 가입 요청을 보내는 api 추가
- 시설 관리자가 가입 요청을 confirm 또는 reject 하는 api 추가
- confirm 할 경우, status가 CONFIRMED로 변경되고 user_facility_relation 관계가 생성됨
- reject 할 경우, status가 REJECTED로 변경됨


## 🌳 반영 브랜치
- `ownue -> main`


## 🌟 체크리스트
- [ ] 불필요한 코드/로그 제거
