### PR TITLE
feat, refactor: 수거 기록 상태 변경 api 추가 및 qr 스캔 api 리팩토링

### DIFF
--- a/src/main/java/com/labify/backend/config/SecurityConfig.java
+++ b/src/main/java/com/labify/backend/config/SecurityConfig.java
@@ -4,7 +4,6 @@ import com.labify.backend.auth.jwt.JwtAuthFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Role;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -12,8 +11,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.stereotype.Repository;
-import org.springframework.web.bind.annotation.RequestBody;
 
 @Configuration
 @EnableWebSecurity
@@ -38,7 +35,7 @@ public class SecurityConfig {
                 // HTTP 요청에 대한 접근 권한 설정
                 .authorizeHttpRequests(auth -> auth
                         // 아래 경로로 오는 요청은 인증 없이 모두 허용
-                        .requestMatchers("/auth/**").permitAll()
+                        .requestMatchers("/auth/**", "/ai-predict").permitAll()
                         // 그 외 나머지 모든 요청은 인증을 요구
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/labify/backend/disposal/repository/DisposalItemRepository.java
+++ b/src/main/java/com/labify/backend/disposal/repository/DisposalItemRepository.java
@@ -1,9 +1,25 @@
 package com.labify.backend.disposal.repository;
 
 import com.labify.backend.disposal.entity.DisposalItem;
+import com.labify.backend.disposal.entity.DisposalStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface DisposalItemRepository extends JpaRepository<DisposalItem, Long> {
+
+    // 하나의 Pickup Id를 사용해 해당 Pickup과 관련있는 DisposalItem들을 모두 조회
+    @Query("SELECT pri.disposalItem FROM PickupRequestItem pri WHERE pri.pickupRequest.pickup.id = :pickupId")
+    List<DisposalItem> findDisposalItemsByPickupId(@Param("pickupId") Long pickupId);
+
+    // 특정 Pickup ID에 속한 모든 DisposalItem의 상태(status) 목록을 조회
+    @Query("SELECT di.status FROM DisposalItem di " +
+            "JOIN PickupRequestItem pri ON di.id = pri.disposalItem.id " +
+            "JOIN pri.pickupRequest pr " +
+            "WHERE pr.pickup.id = :pickupId")
+    List<DisposalStatus> findStatusesByPickupId(@Param("pickupId") Long pickupId);
 }

--- a/src/main/java/com/labify/backend/pickup/controller/PickupController.java
+++ b/src/main/java/com/labify/backend/pickup/controller/PickupController.java
@@ -48,7 +48,7 @@ public class PickupController {
         return ResponseEntity.ok(pickups);
     }
 
-    // [GET] /pickup/today
+    // [GET] /pickups/today
     @GetMapping("/today")
     public ResponseEntity<List<PickupSummaryDto>> getTodaysPickups(
             @AuthenticationPrincipal(expression = "user") User user) {
@@ -57,7 +57,7 @@ public class PickupController {
         return ResponseEntity.ok(pickups);
     }
 
-    // [PATCH] /pickup/{pickupId}/status
+    // [PATCH] /pickups/{pickupId}/status
     @PatchMapping("/{pickupId}/status")
     public ResponseEntity<PickupSummaryDto> updatePickupStatus(
             @PathVariable Long pickupId,

--- a/src/main/java/com/labify/backend/pickup/entity/PickupStatus.java
+++ b/src/main/java/com/labify/backend/pickup/entity/PickupStatus.java
@@ -2,7 +2,7 @@ package com.labify.backend.pickup.entity;
 
 public enum PickupStatus {
     REQUESTED,  // 요청된 상태
-//    PROCESSED,  // 수거 중
+    PROCESSING,  // 수거 중
     COMPLETED,  // 처리 완료
     CANCELED    // 취소
 }


### PR DESCRIPTION
## 📌 작업 유형 (해당 사항 체크)
- [x] ✨ 기능 추가
- [x] 🐛 버그 수정
- [x] ♻️ 리팩토링
- [ ] 📝 문서 수정
- [ ] 🔧 설정 변경

---

## ✏️ 관련 이슈
- X


## 📖 작업 내용
- pickup 테이블의 status를 변경하는 api 추가 (pickup_request와 disposal_item 모두 함께 변경)
- qr 스캔 api 리팩토링 (pickup, pickup_request, disposal_item 모두 변경 / pickup과 연관된 disposal_item 상태따라서 자동 업데이트)
- /ai-predict 요청 인증 없이 허용 (권한 오류 수정용)


## 🌳 반영 브랜치
- `ownue -> main`


## 🌟 체크리스트
- [ ] 불필요한 코드/로그 제거